### PR TITLE
UX: Change NON_RESPONSIVE state to UNKNOWN

### DIFF
--- a/yarnitor/background/worker.py
+++ b/yarnitor/background/worker.py
@@ -320,7 +320,7 @@ class YARNModel(object, metaclass=Singleton):
             if std_info is None:
                 ah = BaseHandler.from_yarn_application_info(app)
                 std_info = ah.generate_standardized_info(app)
-                std_info["state"] = "NON_RESPONSIVE"
+                std_info["state"] = "UNKNOWN"
 
             return std_info
 


### PR DESCRIPTION
Its not necessarily that the application is non-responsive when the
background process fails to fetch its info. It could be the yarn proxy
is having issues, yarnitor itself cannot reach the proxy, etc. The
non-responsive state leads users to always think there's something wrong
with the app when really all it means is that the state of the app is
currently unknown.