### PR TITLE
Track and display time data are refreshed from YARN

### DIFF
--- a/yarnitor/api.py
+++ b/yarnitor/api.py
@@ -19,7 +19,11 @@ def get_model():
 
 @api_bp.route('/api/status')
 def status():
-    return jsonify({'status': 'ok'})
+    ym = get_model()
+    return jsonify({
+        'status': 'ok',
+        'refresh_datetime': ym.refresh_datetime()
+    })
 
 
 @api_bp.route('/api/applications')

--- a/yarnitor/background/worker.py
+++ b/yarnitor/background/worker.py
@@ -13,6 +13,7 @@ REDIS_ENDPOINT :
 
 import atexit
 import concurrent.futures
+import datetime
 import logging
 import os
 import time
@@ -351,6 +352,11 @@ class YARNModel(object, metaclass=Singleton):
         logger.debug("generating listing")
         self.state["current"] = self._generate_listing()
         self.state["cluster-metrics"] = self.yarn_handler.cluster_metrics()
+        # Make the datetime conform to true ISO-8601 by adding Z(ulu) to indicate
+        # this is truly a UTC time (without a timezone, the spec says it should be
+        # treated as local time which is definitely NOT what we want)
+        # https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators
+        self.state["refresh-datetime"] = datetime.datetime.utcnow().isoformat() + 'Z'
         self.redis_client.set(YARN_STATUS_KEY, json.dumps(self.state))
 
     def loop(self):

--- a/yarnitor/model.py
+++ b/yarnitor/model.py
@@ -17,16 +17,24 @@ class Singleton(type):
 
 
 class YARNModel(object, metaclass=Singleton):
-    """Model class that exposes various yarn metrics.
-
-    Backed by redis.
+    """Model class that exposes YARN metrics stored in redis
+    by a separate worker process.
     """
-
     @property
     @cache.cached(timeout=2, key_prefix="yarnmodel.state")
     def state(self):
         state = redis_store.get(YARN_STATUS_KEY)
         return json.loads(state) if state is not None else {}
+
+    def refresh_datetime(self):
+        """Get the UTC datetime of the last data fetch.
+
+        Returns
+        =======
+        str
+            ISO-8601 datetime string
+        """
+        return self.state.get("refresh-datetime", '')
 
     def applications(self):
         return self.state.get("current", {})

--- a/yarnitor/static/js/main.js
+++ b/yarnitor/static/js/main.js
@@ -118,7 +118,6 @@ $(document).ready(function() {
                 }
             },
             {data: "allocatedVCores", title: "VCPUs"},
-            // TODO: human readable
             {
                 data: "allocatedMB",
                 title: "Memory (GB)",
@@ -159,19 +158,34 @@ $(document).ready(function() {
         console.log('yarnitor:xhr.dt');
         // destroy the popovers before the draw phase kicks in.
         $('[data-toggle="popover"]').popover("destroy");
-        var now = (new Date()).toLocaleString();
-        $('.dataTables_refreshed').text('Refreshed ' + now);
         pageScrollPos = $('div.dataTables_scrollBody').scrollTop();
     });
 
+    var reload_datetime = function() {
+        $.get({
+            url: YARNITOR_BASE_URL+"/api/status",
+            dataType: 'json'
+        }).done(function(data) {
+            // Show datetime data was last refreshed from the YARN API
+            // if that information is available, else leave the display alone
+            if(data.refresh_datetime) {
+                var d = (new Date(data.refresh_datetime)).toLocaleString();
+                $('.dataTables_refreshed').text('Showing data from ' + d);
+            }
+        });
+    }
+
     setInterval(function() {
+        console.log('yarnitor:refresh');
         table.ajax.reload();
         cluster_table.ajax.reload();
-        console.log('yarnitor:refresh');
+        reload_datetime();
     }, YARNITOR_REFRESH_INTERVAL_S * 1000);
 
     // Throw exceptions in the console, not in alert dialogs
     $.fn.dataTable.ext.errMode = 'throw';
+    // Immediately try to fetch datetime of last data refresh
+    reload_datetime();
 
     console.log('yarnitor:dom-ready');
 });


### PR DESCRIPTION
Replace frontend logic which shows the datetime that the browser refreshes
with the datetime that the backend worker last successfully pulled the
data from YARN.

Fixes #9