### PR TITLE
Fix failed task progress bar color

### DIFF
--- a/yarnitor/static/css/main.css
+++ b/yarnitor/static/css/main.css
@@ -93,6 +93,9 @@ h1 .title {
 }
 
 .progress-bar-info {
-    background-color: #82a1ff;
+    background-color: #82a1ff !important;
 }
 
+.progress-bar-danger {
+    background-color: #d9534f !important;
+}


### PR DESCRIPTION
It was lost when the color scheme was matched to the logo